### PR TITLE
Change get() return type to support proxy iterators (like std::vector<bool>)

### DIFF
--- a/include/product_iterator.hpp
+++ b/include/product_iterator.hpp
@@ -79,11 +79,7 @@ class product_iterator:
       // Gets the end iterator to be compared
       product_iterator<Containers...> get_end() const;
 
-      // Enables access to a single value instead of the whole tuple. This
-      // method is preffered to the operator* as it doesn't require tuple
-      // construction. Behaves like std::get<I>(*iterator).
-      template <size_t I>
-      typename std::tuple_element<I, value_type>::type const& get() const;
+      // See public get() member bellow private section
 
     private:
       // Boost stuff due to facade
@@ -121,6 +117,20 @@ class product_iterator:
       // this thing. We also can't keep a single copy because each element of
       // the tuple is a const&, so it can't be constructed by itself.
       mutable value_type* current_tuple_;
+
+    public:
+      // Enables access to a single value instead of the whole tuple. This
+      // method is preffered to the operator* as it doesn't require tuple
+      // construction. Behaves like std::get<I>(*iterator).
+      template <size_t I>
+      auto get() const -> decltype(*std::get<I>(current_)) {
+        // This function must come after the private section as it needs
+        // `current_` to be defined before it for use in the trailing return
+        // type.
+
+        // As only a single value is needed, gathers it from its iterator.
+        return *std::get<I>(current_);
+      }
 };
 
 template <class... Containers>

--- a/include/product_iterator_impl.hpp
+++ b/include/product_iterator_impl.hpp
@@ -53,16 +53,6 @@ product_iterator<Containers...>::get_end() const {
 }
 
 template <class... Containers>
-template <size_t I>
-typename
-std::tuple_element<I,typename product_iterator<Containers...>::value_type>::type
-const &
-product_iterator<Containers...>::get() const {
-  // As only a single value is needed, gathers it from its iterator.
-  return *std::get<I>(current_);
-}
-
-template <class... Containers>
 template <size_t I, class T1, class... Types>
 void product_iterator<Containers...>::copy_iterator(T1 const& container,
     Types const&... containers) {

--- a/test/product_iterator.cpp
+++ b/test/product_iterator.cpp
@@ -72,3 +72,19 @@ TEST_F(ProductIteratorTest, DoubleLoopProxy) {
 
   EXPECT_EQ(end, it);
 }
+
+TEST_F(ProductIteratorTest, BoolVector)
+{
+	const std::vector<bool> v1 = { true, false };
+	const std::vector<bool> v2 = { true };
+
+	auto it = make_product_iterator( v1, v2 );
+	const auto end = it.get_end();
+
+	EXPECT_TRUE( it.get<0>() );
+	EXPECT_TRUE( it.get<1>() );
+
+	++it;
+	EXPECT_FALSE( it.get<0>() );
+	EXPECT_TRUE( it.get<1>() );
+}


### PR DESCRIPTION
A new test for std::vector<bool> was added. This new test would emit the following errors in GCC 5.2 before this fix:

```
product_iterator_impl.hpp:62:31: error: returning reference to temporary [-Werror=return-local-addr]
   return *std::get<I>(current_);
                               ^
product_iterator_impl.hpp: In instantiation of ‘const typename std::tuple_element<I, std::tuple<const typename std::remove_reference<typename Containers::value_type>::type& ...> >::type& product_iterator<Containers>::get() const [with long unsigned int I = 1ul; Containers = {std::vector<bool, std::allocator<bool> >, std::vector<bool, std::allocator<bool> >}; typename std::tuple_element<I, std::tuple<const typename std::remove_reference<typename Containers::value_type>::type& ...> >::type = const bool&]’
```
